### PR TITLE
Update location info endpoint for geohash and lat/lng

### DIFF
--- a/src/routes/v1/location.ts
+++ b/src/routes/v1/location.ts
@@ -28,7 +28,15 @@ const route = new Elysia({ prefix: "/location" })
     
     // Check if lat and lng are provided
     if (query.lat && query.lng) {
-      const location = await geoCtrl.reverseGeocode(query.lat, query.lng);
+      const lat = parseFloat(query.lat);
+      const lng = parseFloat(query.lng);
+      if (isNaN(lat) || isNaN(lng)) {
+        set.status = 400;
+        return {
+          message: "Bad request: 'lat' and 'lng' must be valid numeric coordinates.",
+        };
+      }
+      const location = await geoCtrl.reverseGeocode(lat, lng);
       const locationInfo = await locCtrl.getLocationInfo(location);
       return locationInfo;
     }

--- a/src/routes/v1/location.ts
+++ b/src/routes/v1/location.ts
@@ -12,16 +12,32 @@ const route = new Elysia({ prefix: "/location" })
   .decorate("locCtrl", new LocationController(db))
   .decorate("geoCtrl", new GeocodingController(db))
   .get("/info", async ({ query, locCtrl, geoCtrl, set }) => {
-    const location = await geoCtrl.getLocationFromGeohash(query.geohash);
-    if (!location) {
-      set.status = 404;
-      return {
-        message: `Could not find location info for the given geohash: ${query.geohash}. ` +
-          `Did you first call the /v1/locate endpoint with lat/lng to get the location?`,
-      };
+    // Check if geohash is provided
+    if (query.geohash) {
+      const location = await geoCtrl.getLocationFromGeohash(query.geohash);
+      if (!location) {
+        set.status = 404;
+        return {
+          message: `Could not find location info for the given geohash: ${query.geohash}. ` +
+            `Did you first call the /v1/locate endpoint with lat/lng to get the location?`,
+        };
+      }
+      const locationInfo = await locCtrl.getLocationInfo(location);
+      return locationInfo;
     }
-    const locationInfo = await locCtrl.getLocationInfo(location);
-    return locationInfo;
+    
+    // Check if lat and lng are provided
+    if (query.lat && query.lng) {
+      const location = await geoCtrl.reverseGeocode(query.lat, query.lng);
+      const locationInfo = await locCtrl.getLocationInfo(location);
+      return locationInfo;
+    }
+    
+    // Neither geohash nor lat/lng provided
+    set.status = 400;
+    return {
+      message: "Bad request: Either 'geohash' or both 'lat' and 'lng' parameters must be provided.",
+    };
   }, {
     tags: ["location"],
     query: LocationInfoRequestSchema,

--- a/src/services/locationinfo.ts
+++ b/src/services/locationinfo.ts
@@ -11,7 +11,9 @@ import { locationInfoPrompt } from "../prompts/location-info";
 import adze from "adze";
 
 export const LocationInfoRequestSchema = t.Object({
-  geohash: t.String(),
+  geohash: t.Optional(t.String()),
+  lat: t.Optional(t.String()),
+  lng: t.Optional(t.String()),
 });
 
 export type LocationInfoRequest = Static<typeof LocationInfoRequestSchema>;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update `/v1/location/info` endpoint to accept `lat`/`lng` query parameters in addition to `geohash` for improved flexibility.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The endpoint now supports querying location information using either a geohash string or a pair of latitude and longitude coordinates. If neither `geohash` nor `lat`/`lng` are provided, a 400 Bad Request error is returned.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ad35dd2-8c2a-4e5f-97cf-281618ada03c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8ad35dd2-8c2a-4e5f-97cf-281618ada03c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>